### PR TITLE
Automatic baseline JPEG conversion

### DIFF
--- a/crosspoint_reader/baseline_jpeg.py
+++ b/crosspoint_reader/baseline_jpeg.py
@@ -1,3 +1,11 @@
+"""
+Baseline JPEG Converter Module
+
+Converts images inside EPUB files to baseline (non-progressive) JPEG format.
+This improves compatibility with e-readers that struggle with progressive JPEGs
+or other image formats like PNG/WebP.
+"""
+
 import zipfile
 import tempfile
 import os
@@ -7,11 +15,20 @@ from io import BytesIO
 
 
 def convert_image_to_baseline(image_data, quality=85):
+    """
+    Convert image data to baseline JPEG format.
+    
+    Handles transparency by compositing onto a white background,
+    since JPEG doesn't support alpha channels.
+    
+    Returns None if conversion fails for any reason.
+    """
     from PIL import Image
 
     try:
         img = Image.open(BytesIO(image_data))
 
+        # Handle images with transparency - composite onto white background
         if img.mode in ('RGBA', 'LA', 'P'):
             background = Image.new('RGB', img.size, (255, 255, 255))
             if img.mode == 'P':
@@ -24,6 +41,7 @@ def convert_image_to_baseline(image_data, quality=85):
         elif img.mode != 'RGB':
             img = img.convert('RGB')
 
+        # Save as baseline JPEG - the key is progressive=False
         output = BytesIO()
         img.save(output, format='JPEG', quality=quality, progressive=False, optimize=False)
         return output.getvalue()
@@ -32,17 +50,31 @@ def convert_image_to_baseline(image_data, quality=85):
 
 
 def convert_epub_images(epub_path, output_path=None, quality=85, logger=None):
+    """
+    Convert all images in an EPUB to baseline JPEG.
+    
+    This handles the whole process:
+    - Converting PNG, GIF, WebP, BMP to JPEG
+    - Re-encoding existing JPEGs as baseline (non-progressive)
+    - Updating all the references in XHTML, HTML, CSS, NCX files
+    - Fixing the media-type attributes in the OPF manifest
+    
+    The EPUB spec requires mimetype to be the first file and uncompressed,
+    so we're careful to preserve that.
+    """
     if output_path is None:
         output_path = epub_path
 
     converted_count = 0
-    renamed_files = {}
+    renamed_files = {}  # old filename -> new .jpg filename
 
+    # We'll write to a temp file first, then move it into place
     temp_fd, temp_path = tempfile.mkstemp(suffix='.epub')
     os.close(temp_fd)
 
     try:
         with zipfile.ZipFile(epub_path, 'r') as zin:
+            # First pass: figure out which files need to be renamed
             for item in zin.infolist():
                 lower_name = item.filename.lower()
                 if lower_name.endswith(('.png', '.gif', '.webp', '.bmp')):
@@ -50,12 +82,14 @@ def convert_epub_images(epub_path, output_path=None, quality=85, logger=None):
                     new_name = base_name + '.jpg'
                     renamed_files[item.filename] = new_name
 
+            # Second pass: process everything
             with zipfile.ZipFile(temp_path, 'w', zipfile.ZIP_DEFLATED) as zout:
                 for item in zin.infolist():
                     data = zin.read(item.filename)
                     filename = item.filename
                     lower_name = filename.lower()
 
+                    # Image files get converted to baseline JPEG
                     if lower_name.endswith(('.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp')):
                         new_data = convert_image_to_baseline(data, quality)
                         if new_data:
@@ -66,6 +100,7 @@ def convert_epub_images(epub_path, output_path=None, quality=85, logger=None):
                                 if logger:
                                     logger(f'[Baseline JPEG] Converted: {item.filename} -> {filename}')
 
+                    # Content files need their image references updated
                     elif lower_name.endswith(('.xhtml', '.html', '.htm', '.css', '.ncx')):
                         try:
                             text = data.decode('utf-8')
@@ -76,16 +111,19 @@ def convert_epub_images(epub_path, output_path=None, quality=85, logger=None):
                                 text = text.replace(old_name, new_name)
                             data = text.encode('utf-8')
                         except Exception:
-                            pass
+                            pass  # If we can't decode it, just leave it alone
 
+                    # OPF needs both filename updates AND media-type fixes
                     elif lower_name.endswith('.opf'):
                         try:
                             text = data.decode('utf-8')
+                            # Update the href attributes
                             for old_name, new_name in renamed_files.items():
                                 old_basename = old_name.split('/')[-1]
                                 new_basename = new_name.split('/')[-1]
                                 text = text.replace(old_basename, new_basename)
                                 text = text.replace(old_name, new_name)
+                            # Fix media-type for files that are now JPEGs
                             text = re.sub(
                                 r'href="([^"]+\.jpg)"([^>]*)media-type="image/(png|gif|webp|bmp)"',
                                 r'href="\1"\2media-type="image/jpeg"',
@@ -100,6 +138,7 @@ def convert_epub_images(epub_path, output_path=None, quality=85, logger=None):
                         except Exception:
                             pass
 
+                    # Write the file - mimetype must be stored uncompressed per EPUB spec
                     if item.filename == 'mimetype':
                         zout.writestr(item, data, compress_type=zipfile.ZIP_STORED)
                     else:
@@ -107,9 +146,11 @@ def convert_epub_images(epub_path, output_path=None, quality=85, logger=None):
                         new_info.compress_type = zipfile.ZIP_DEFLATED
                         zout.writestr(new_info, data)
 
+        # All done - move temp file to final location
         shutil.move(temp_path, output_path)
 
     except Exception as e:
+        # Clean up temp file if something went wrong
         if os.path.exists(temp_path):
             os.remove(temp_path)
         raise e

--- a/crosspoint_reader/config.py
+++ b/crosspoint_reader/config.py
@@ -25,6 +25,8 @@ PREFS.defaults['path'] = '/'
 PREFS.defaults['chunk_size'] = 2048
 PREFS.defaults['debug'] = False
 PREFS.defaults['fetch_metadata'] = False
+
+# Baseline JPEG conversion settings
 PREFS.defaults['convert_baseline_jpeg'] = True
 PREFS.defaults['jpeg_quality'] = 85
 
@@ -33,6 +35,8 @@ class CrossPointConfigWidget(QWidget):
     def __init__(self):
         super().__init__()
         layout = QFormLayout(self)
+
+        # Connection settings
         self.host = QLineEdit(self)
         self.port = QSpinBox(self)
         self.port.setRange(1, 65535)
@@ -56,10 +60,12 @@ class CrossPointConfigWidget(QWidget):
         layout.addRow('', self.debug)
         layout.addRow('', self.fetch_metadata)
 
+        # Separator before image conversion section
         separator = QLabel('<hr>')
         separator.setStyleSheet('margin: 10px 0;')
         layout.addRow(separator)
 
+        # Image conversion settings
         image_label = QLabel('<b>Image Conversion</b>')
         layout.addRow(image_label)
 
@@ -67,20 +73,22 @@ class CrossPointConfigWidget(QWidget):
         self.convert_baseline_jpeg.setChecked(PREFS['convert_baseline_jpeg'])
         self.convert_baseline_jpeg.setToolTip(
             'Converts all PNG, GIF, WebP images in EPUBs to baseline (non-progressive) JPEG.\n'
-            'This improves compatibility with e-readers and reduces file size.'
+            'This improves compatibility with e-readers and can reduce file size.'
         )
         layout.addRow('', self.convert_baseline_jpeg)
 
         self.jpeg_quality = QSpinBox(self)
         self.jpeg_quality.setRange(1, 100)
         self.jpeg_quality.setValue(PREFS['jpeg_quality'])
-        self.jpeg_quality.setToolTip('JPEG quality (1-100). Higher = better quality, larger file size.')
+        self.jpeg_quality.setToolTip('JPEG quality (1-100). Higher means better quality but larger file size.')
         layout.addRow('JPEG quality', self.jpeg_quality)
 
+        # Separator before log section
         separator2 = QLabel('<hr>')
         separator2.setStyleSheet('margin: 10px 0;')
         layout.addRow(separator2)
 
+        # Log viewer
         self.log_view = QPlainTextEdit(self)
         self.log_view.setReadOnly(True)
         self.log_view.setPlaceholderText('Discovery log will appear here when debug is enabled.')

--- a/crosspoint_reader/ws_client.py
+++ b/crosspoint_reader/ws_client.py
@@ -112,9 +112,11 @@ class WebSocketClient:
                 self._log('Server closed connection', code, reason)
                 raise WebSocketError('Connection closed')
             if opcode == 0x9:
+                # Ping -> respond with Pong
                 self._send_frame(0xA, payload)
                 continue
             if opcode == 0xA:
+                # Pong -> ignore
                 continue
             if opcode != 0x1:
                 self._log('Ignoring non-text opcode', opcode, len(payload))
@@ -280,6 +282,7 @@ def upload_file(host, port, upload_path, filename, filepath, chunk_size=16384, d
                     progress_cb(sent, size)
                 client.drain_messages()
 
+        # Wait for DONE or ERROR
         while True:
             msg = client.read_text()
             client._log('Received', msg)


### PR DESCRIPTION
Since the xteink doesn't support progressive images I added a toggle that enables automatic conversion of all images inside EPUB into baseline JPEG. It fixes the covers sometimes not showing up in Crosspoint and should be helpful once we get the image inside EPUBs functionality. It also fixes all file references in XHTML, CSS, and OPF files automatically.

I have a standalone plugin version of this and a web app if that's not something you want to do.


<img width="1512" height="982" alt="Zrzut ekranu 2026-02-8 o 15 01 00" src="https://github.com/user-attachments/assets/fe1411e6-39b6-44c6-a313-fa7493dc017f" />
