### PR TITLE
Add 'Send to root' option to bypass folder template

### DIFF
--- a/crosspoint_reader/config.py
+++ b/crosspoint_reader/config.py
@@ -23,6 +23,7 @@ PREFS.defaults['path'] = '/'
 PREFS.defaults['chunk_size'] = 2048
 PREFS.defaults['debug'] = False
 PREFS.defaults['fetch_metadata'] = False
+PREFS.defaults['send_to_root'] = False
 
 
 class CrossPointConfigWidget(QWidget):
@@ -37,6 +38,7 @@ class CrossPointConfigWidget(QWidget):
         self.chunk_size.setRange(512, 65536)
         self.debug = QCheckBox('Enable debug logging', self)
         self.fetch_metadata = QCheckBox('Fetch metadata (slower device list)', self)
+        self.send_to_root = QCheckBox('Send to root (ignore folder template)', self)
 
         self.host.setText(PREFS['host'])
         self.port.setValue(PREFS['port'])
@@ -44,6 +46,7 @@ class CrossPointConfigWidget(QWidget):
         self.chunk_size.setValue(PREFS['chunk_size'])
         self.debug.setChecked(PREFS['debug'])
         self.fetch_metadata.setChecked(PREFS['fetch_metadata'])
+        self.send_to_root.setChecked(PREFS['send_to_root'])
 
         layout.addRow('Host', self.host)
         layout.addRow('Port', self.port)
@@ -51,6 +54,7 @@ class CrossPointConfigWidget(QWidget):
         layout.addRow('Chunk size', self.chunk_size)
         layout.addRow('', self.debug)
         layout.addRow('', self.fetch_metadata)
+        layout.addRow('', self.send_to_root)
 
         self.log_view = QPlainTextEdit(self)
         self.log_view.setReadOnly(True)
@@ -72,6 +76,7 @@ class CrossPointConfigWidget(QWidget):
         PREFS['chunk_size'] = int(self.chunk_size.value())
         PREFS['debug'] = bool(self.debug.isChecked())
         PREFS['fetch_metadata'] = bool(self.fetch_metadata.isChecked())
+        PREFS['send_to_root'] = bool(self.send_to_root.isChecked())
 
     def _refresh_logs(self):
         self.log_view.setPlainText(get_log_text())

--- a/crosspoint_reader/driver.py
+++ b/crosspoint_reader/driver.py
@@ -21,7 +21,7 @@ class CrossPointDevice(DeviceConfig, DevicePlugin):
     description = 'CrossPoint Reader wireless device'
     supported_platforms = ['windows', 'osx', 'linux']
     author = 'CrossPoint Reader'
-    version = (0, 1, 1)
+    version = (0, 2, 0)
 
     # Invalid USB vendor info to avoid USB scans matching.
     VENDOR_ID = [0xFFFF]
@@ -302,7 +302,7 @@ class CrossPointDevice(DeviceConfig, DevicePlugin):
                 filepath = infile
             filename = os.path.basename(name)
             subdirs = []
-            if metadata and i < len(metadata):
+            if metadata and i < len(metadata) and not PREFS['send_to_root']:
                 subdirs, filename = self._format_upload_path(metadata[i], filename)
 
             if subdirs:


### PR DESCRIPTION
## Summary
- Adds a new "Send to root (ignore folder template)" checkbox in plugin settings
- When enabled, books are uploaded directly to the configured upload path instead of subdirectories based on Calibre's send template (e.g., `/Author Name/Book Title.epub`)

## Motivation
Some users prefer a flat file structure on their device rather than having books organized into author/title subdirectories. This option allows bypassing the template formatting entirely.

## Changes
- **config.py**: Added `send_to_root` preference with UI checkbox
- **driver.py**: Skip `_format_upload_path()` when preference is enabled

## Test plan
- [ ] Install plugin in Calibre
- [ ] Open Preferences > Plugins > CrossPoint Reader > Configure
- [ ] Verify "Send to root" checkbox appears
- [ ] With option disabled: send a book, verify it goes to `/Author/Title.epub`
- [ ] With option enabled: send a book, verify it goes directly to `/Title.epub`

/!\ I built this with Claude Code. This works, but please don't trust this code as is!