### PR TITLE
Improve CrossPoint upload reliability

### DIFF
--- a/crosspoint_reader/README.md
+++ b/crosspoint_reader/README.md
@@ -15,6 +15,8 @@ Default settings:
 - Host fallback: 192.168.4.1
 - Port: 81
 - Upload path: /
+- Upload reliability: 3 retries, 2s retry delay, 1s delay between books,
+  30s socket timeout
 
 ## Optimizer
 

--- a/crosspoint_reader/config.py
+++ b/crosspoint_reader/config.py
@@ -27,6 +27,10 @@ PREFS.defaults['chunk_size'] = 2048
 PREFS.defaults['debug'] = False
 PREFS.defaults['fetch_metadata'] = False
 PREFS.defaults['send_to_root'] = False
+PREFS.defaults['upload_retries'] = 3
+PREFS.defaults['retry_delay'] = 2
+PREFS.defaults['book_cooldown'] = 1
+PREFS.defaults['socket_timeout'] = 30
 # Optimizer settings (mirrors the CrossPoint web server optimizer).
 PREFS.defaults['optimize'] = False
 PREFS.defaults['optimize_grayscale'] = True
@@ -45,6 +49,17 @@ class CrossPointConfigWidget(QWidget):
         self.path = QLineEdit(self)
         self.chunk_size = QSpinBox(self)
         self.chunk_size.setRange(512, 65536)
+        self.upload_retries = QSpinBox(self)
+        self.upload_retries.setRange(0, 10)
+        self.retry_delay = QSpinBox(self)
+        self.retry_delay.setRange(0, 60)
+        self.retry_delay.setSuffix(' s')
+        self.book_cooldown = QSpinBox(self)
+        self.book_cooldown.setRange(0, 60)
+        self.book_cooldown.setSuffix(' s')
+        self.socket_timeout = QSpinBox(self)
+        self.socket_timeout.setRange(5, 300)
+        self.socket_timeout.setSuffix(' s')
         self.debug = QCheckBox('Enable debug logging', self)
         self.fetch_metadata = QCheckBox('Fetch metadata for side-loaded books (downloads each once on connect)', self)
         self.send_to_root = QCheckBox('Send to root (ignore folder template)', self)
@@ -65,6 +80,10 @@ class CrossPointConfigWidget(QWidget):
         self.port.setValue(PREFS['port'])
         self.path.setText(PREFS['path'])
         self.chunk_size.setValue(PREFS['chunk_size'])
+        self.upload_retries.setValue(PREFS['upload_retries'])
+        self.retry_delay.setValue(PREFS['retry_delay'])
+        self.book_cooldown.setValue(PREFS['book_cooldown'])
+        self.socket_timeout.setValue(PREFS['socket_timeout'])
         self.debug.setChecked(PREFS['debug'])
         self.fetch_metadata.setChecked(PREFS['fetch_metadata'])
         self.send_to_root.setChecked(PREFS['send_to_root'])
@@ -85,6 +104,18 @@ class CrossPointConfigWidget(QWidget):
 
         layout.addRow('Upload path', self.path)
         layout.addRow('Chunk size', self.chunk_size)
+
+        reliability_heading = QLabel('<b>Upload reliability</b>')
+        layout.addRow(reliability_heading)
+        reliability_notice = QLabel('Retries resend the current book from the beginning after transient WebSocket failures.')
+        reliability_notice.setWordWrap(True)
+        reliability_notice.setStyleSheet('color: gray; font-style: italic;')
+        layout.addRow('', reliability_notice)
+        layout.addRow('Upload retries', self.upload_retries)
+        layout.addRow('Retry delay', self.retry_delay)
+        layout.addRow('Delay between books', self.book_cooldown)
+        layout.addRow('Socket timeout', self.socket_timeout)
+
         layout.addRow('', self.debug)
         layout.addRow('', self.fetch_metadata)
         layout.addRow('', self.send_to_root)
@@ -129,6 +160,10 @@ class CrossPointConfigWidget(QWidget):
         PREFS['port'] = int(self.port.value())
         PREFS['path'] = self.path.text().strip() or PREFS.defaults['path']
         PREFS['chunk_size'] = int(self.chunk_size.value())
+        PREFS['upload_retries'] = int(self.upload_retries.value())
+        PREFS['retry_delay'] = int(self.retry_delay.value())
+        PREFS['book_cooldown'] = int(self.book_cooldown.value())
+        PREFS['socket_timeout'] = int(self.socket_timeout.value())
         PREFS['debug'] = bool(self.debug.isChecked())
         PREFS['fetch_metadata'] = bool(self.fetch_metadata.isChecked())
         PREFS['send_to_root'] = bool(self.send_to_root.isChecked())

--- a/crosspoint_reader/driver.py
+++ b/crosspoint_reader/driver.py
@@ -342,16 +342,21 @@ class CrossPointDevice(DeviceConfig, DevicePlugin):
                 current = current + '/' + sub
         return current
 
-    def _delete_upload_path_on_device(self, lpath):
-        """Best-effort cleanup for a possibly partial upload."""
+    def _delete_paths_on_device(self, paths):
         import json as _json
-        norm_path = self._normalize_device_path(lpath)
+        norm_paths = [self._normalize_device_path(p) for p in paths]
         url = self._http_base() + '/delete'
-        body = urllib.parse.urlencode({'paths': _json.dumps([norm_path])}).encode('utf-8')
+        # Server expects form field 'paths' containing a JSON array string.
+        body = urllib.parse.urlencode({'paths': _json.dumps(norm_paths)}).encode('utf-8')
         req = urllib.request.Request(url, data=body, method='POST',
                                      headers={'Content-Type': 'application/x-www-form-urlencoded'})
         with urllib.request.urlopen(req, timeout=10) as resp:
             resp.read()
+            return resp.status
+
+    def _delete_upload_path_on_device(self, lpath):
+        """Best-effort cleanup for a possibly partial upload."""
+        self._delete_paths_on_device([lpath])
 
     def upload_books(self, files, names, on_card=None, end_session=True, metadata=None):
         host = self.device_host or PREFS['host']
@@ -589,17 +594,11 @@ class CrossPointDevice(DeviceConfig, DevicePlugin):
         return p
 
     def delete_books(self, paths, end_session=True):
-        import json as _json
         norm_paths = [self._normalize_device_path(p) for p in paths]
         self._log(f'[CrossPoint] deleting {len(norm_paths)} books: {norm_paths}')
-        url = self._http_base() + '/delete'
-        # Server expects form field 'paths' containing a JSON array string
-        body = urllib.parse.urlencode({'paths': _json.dumps(norm_paths)}).encode('utf-8')
-        req = urllib.request.Request(url, data=body, method='POST',
-                                    headers={'Content-Type': 'application/x-www-form-urlencoded'})
         try:
-            with urllib.request.urlopen(req, timeout=10) as resp:
-                self._log(f'[CrossPoint] delete OK: {resp.status}')
+            status = self._delete_paths_on_device(norm_paths)
+            self._log(f'[CrossPoint] delete OK: {status}')
         except urllib.error.HTTPError as exc:
             err_body = exc.read().decode('utf-8', 'ignore') if exc.fp else ''
             self._log(f'[CrossPoint] delete error {exc.code}: {err_body}')

--- a/crosspoint_reader/driver.py
+++ b/crosspoint_reader/driver.py
@@ -342,6 +342,17 @@ class CrossPointDevice(DeviceConfig, DevicePlugin):
                 current = current + '/' + sub
         return current
 
+    def _delete_upload_path_on_device(self, lpath):
+        """Best-effort cleanup for a possibly partial upload."""
+        import json as _json
+        norm_path = self._normalize_device_path(lpath)
+        url = self._http_base() + '/delete'
+        body = urllib.parse.urlencode({'paths': _json.dumps([norm_path])}).encode('utf-8')
+        req = urllib.request.Request(url, data=body, method='POST',
+                                     headers={'Content-Type': 'application/x-www-form-urlencoded'})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+
     def upload_books(self, files, names, on_card=None, end_session=True, metadata=None):
         host = self.device_host or PREFS['host']
         port = self.device_port or PREFS['port']
@@ -351,6 +362,11 @@ class CrossPointDevice(DeviceConfig, DevicePlugin):
             self._log(f'[CrossPoint] chunk_size capped to 2048 (was {chunk_size})')
             chunk_size = 2048
         debug = PREFS['debug']
+        upload_retries = max(0, int(PREFS['upload_retries']))
+        retry_delay = max(0, int(PREFS['retry_delay']))
+        book_cooldown = max(0, int(PREFS['book_cooldown']))
+        socket_timeout = max(5, int(PREFS['socket_timeout']))
+        max_attempts = upload_retries + 1
 
         # Normalize base upload path
         base_path = upload_path
@@ -419,18 +435,55 @@ class CrossPointDevice(DeviceConfig, DevicePlugin):
                                          'Transferring books to device...')
 
             try:
-                ws_client.upload_file(
-                    host,
-                    port,
-                    target_dir,
-                    filename,
-                    send_path,
-                    chunk_size=chunk_size,
-                    debug=debug,
-                    progress_cb=_progress,
-                    logger=self._log,
-                )
+                last_error = None
+                for attempt in range(1, max_attempts + 1):
+                    try:
+                        if attempt > 1:
+                            self.report_progress(i / float(total),
+                                                 'Retrying transfer to device...')
+                        ws_client.upload_file(
+                            host,
+                            port,
+                            target_dir,
+                            filename,
+                            send_path,
+                            chunk_size=chunk_size,
+                            debug=debug,
+                            progress_cb=_progress,
+                            logger=self._log,
+                            timeout=socket_timeout,
+                        )
+                        last_error = None
+                        break
+                    except ws_client.UploadError as exc:
+                        last_error = exc
+                        self._log(f'[CrossPoint] upload failed for {filename} '
+                                  f'attempt {attempt}/{max_attempts}: {exc}')
+                        if exc.upload_started:
+                            try:
+                                self._delete_upload_path_on_device(lpath)
+                            except Exception as cleanup_exc:
+                                self._log(f'[CrossPoint] partial upload cleanup ignored '
+                                          f'for {lpath}: {cleanup_exc}')
+                        if attempt >= max_attempts:
+                            break
+                        if retry_delay > 0:
+                            time.sleep(retry_delay)
+                    except (ws_client.WebSocketError, OSError) as exc:
+                        last_error = exc
+                        self._log(f'[CrossPoint] upload failed for {filename} '
+                                  f'attempt {attempt}/{max_attempts}: {exc}')
+                        if attempt >= max_attempts:
+                            break
+                        if retry_delay > 0:
+                            time.sleep(retry_delay)
+
+                if last_error is not None:
+                    raise ControlError(desc=f'Upload failed for {filename} after '
+                                      f'{max_attempts} attempt(s): {last_error}')
                 paths.append((lpath, os.path.getsize(send_path)))
+                if book_cooldown > 0 and i + 1 < total:
+                    time.sleep(book_cooldown)
             finally:
                 if opt_temp is not None:
                     try:

--- a/crosspoint_reader/ws_client.py
+++ b/crosspoint_reader/ws_client.py
@@ -10,6 +10,12 @@ class WebSocketError(RuntimeError):
     pass
 
 
+class UploadError(WebSocketError):
+    def __init__(self, message, upload_started=False):
+        super().__init__(message)
+        self.upload_started = upload_started
+
+
 class WebSocketClient:
     def __init__(self, host, port, timeout=10, debug=False, logger=None):
         self.host = host
@@ -28,7 +34,10 @@ class WebSocketClient:
                 print(msg)
 
     def connect(self):
-        self.sock = socket.create_connection((self.host, self.port), self.timeout)
+        try:
+            self.sock = socket.create_connection((self.host, self.port), self.timeout)
+        except OSError as exc:
+            raise WebSocketError('Failed to connect: ' + str(exc)) from exc
         key = base64.b64encode(os.urandom(16)).decode('ascii')
         req = (
             'GET / HTTP/1.1\r\n'
@@ -39,7 +48,10 @@ class WebSocketClient:
             'Sec-WebSocket-Version: 13\r\n'
             '\r\n'
         )
-        self.sock.sendall(req.encode('ascii'))
+        try:
+            self.sock.sendall(req.encode('ascii'))
+        except OSError as exc:
+            raise WebSocketError('Failed to send handshake: ' + str(exc)) from exc
         data = self._read_http_response()
         if b' 101 ' not in data.split(b'\r\n', 1)[0]:
             raise WebSocketError('Handshake failed: ' + data.split(b'\r\n', 1)[0].decode('ascii', 'ignore'))
@@ -49,7 +61,10 @@ class WebSocketClient:
         self.sock.settimeout(self.timeout)
         data = b''
         while b'\r\n\r\n' not in data:
-            chunk = self.sock.recv(1024)
+            try:
+                chunk = self.sock.recv(1024)
+            except OSError as exc:
+                raise WebSocketError('Failed to read handshake: ' + str(exc)) from exc
             if not chunk:
                 break
             data += chunk
@@ -95,7 +110,10 @@ class WebSocketClient:
         masked = bytearray(payload)
         for i in range(length):
             masked[i] ^= mask[i % 4]
-        self.sock.sendall(header + masked)
+        try:
+            self.sock.sendall(header + masked)
+        except OSError as exc:
+            raise WebSocketError('Failed to send WebSocket frame: ' + str(exc)) from exc
 
     def read_text(self):
         deadline = time.time() + self.timeout
@@ -146,7 +164,10 @@ class WebSocketClient:
     def _recv_exact(self, n):
         data = b''
         while len(data) < n:
-            chunk = self.sock.recv(n - len(data))
+            try:
+                chunk = self.sock.recv(n - len(data))
+            except OSError as exc:
+                raise WebSocketError('Failed to read WebSocket frame: ' + str(exc)) from exc
             if not chunk:
                 raise WebSocketError('Socket closed')
             data += chunk
@@ -275,43 +296,50 @@ def discover_device(timeout=2.0, debug=False, logger=None, extra_hosts=None):
 
 
 def upload_file(host, port, upload_path, filename, filepath, chunk_size=16384, debug=False, progress_cb=None,
-                logger=None):
-    client = WebSocketClient(host, port, timeout=10, debug=debug, logger=logger)
+                logger=None, timeout=10):
+    client = WebSocketClient(host, port, timeout=timeout, debug=debug, logger=logger)
+    upload_started = False
     try:
-        client.connect()
-        size = os.path.getsize(filepath)
-        start = f'START:{filename}:{size}:{upload_path}'
-        client._log('Sending START', start)
-        client.send_text(start)
+        try:
+            client.connect()
+            size = os.path.getsize(filepath)
+            start = f'START:{filename}:{size}:{upload_path}'
+            client._log('Sending START', start)
+            client.send_text(start)
 
-        msg = client.read_text()
-        client._log('Received', msg)
-        if not msg:
-            raise WebSocketError('Unexpected response: <empty>')
-        if msg.startswith('ERROR'):
-            raise WebSocketError(msg)
-        if msg != 'READY':
-            raise WebSocketError('Unexpected response: ' + msg)
-
-        sent = 0
-        with open(filepath, 'rb') as f:
-            while True:
-                chunk = f.read(chunk_size)
-                if not chunk:
-                    break
-                client.send_binary(chunk)
-                sent += len(chunk)
-                if progress_cb:
-                    progress_cb(sent, size)
-                client.drain_messages()
-
-        # Wait for DONE or ERROR
-        while True:
             msg = client.read_text()
             client._log('Received', msg)
-            if msg == 'DONE':
-                return
+            if not msg:
+                raise WebSocketError('Unexpected response: <empty>')
             if msg.startswith('ERROR'):
                 raise WebSocketError(msg)
+            if msg != 'READY':
+                raise WebSocketError('Unexpected response: ' + msg)
+
+            sent = 0
+            with open(filepath, 'rb') as f:
+                while True:
+                    chunk = f.read(chunk_size)
+                    if not chunk:
+                        break
+                    upload_started = True
+                    client.send_binary(chunk)
+                    sent += len(chunk)
+                    if progress_cb:
+                        progress_cb(sent, size)
+                    client.drain_messages()
+
+            # Wait for DONE or ERROR
+            while True:
+                msg = client.read_text()
+                client._log('Received', msg)
+                if msg == 'DONE':
+                    return
+                if msg.startswith('ERROR'):
+                    raise WebSocketError(msg)
+        except UploadError:
+                raise
+        except WebSocketError as exc:
+            raise UploadError(str(exc), upload_started=upload_started) from exc
     finally:
         client.close()

--- a/crosspoint_reader/ws_client.py
+++ b/crosspoint_reader/ws_client.py
@@ -338,8 +338,8 @@ def upload_file(host, port, upload_path, filename, filepath, chunk_size=16384, d
                 if msg.startswith('ERROR'):
                     raise WebSocketError(msg)
         except UploadError:
-                raise
-        except WebSocketError as exc:
+            raise
+        except (WebSocketError, OSError) as exc:
             raise UploadError(str(exc), upload_started=upload_started) from exc
     finally:
         client.close()


### PR DESCRIPTION
## Summary

- Add configurable upload reliability settings for CrossPoint transfers: retries, retry delay, delay between books, and socket timeout.
- Retry whole-book websocket uploads when transient socket failures occur.
- Add guarded cleanup for partial uploads after file data has started sending.
- Normalize low-level websocket socket failures into clearer upload errors.

## Details

The observed failures happen while sending websocket frames to the Xteink X4 with CrossPoint, especially when multiple books are uploaded one after another. One likely contributor is flaky Wi-Fi, which is a common occurrence with my home router. The main usability issue is that any single timeout, broken pipe, or similar transient connection failure completely stops the whole transfer process with a connection exception, for example:

```
  Traceback (most recent call last):
    File "/nix/store/75bf5mv3r07nn3skn9j2hyv6i8zksyhm-calibre-9.10.0/lib/calibre/calibre/gui2/device.py", line 110, in run
      self.result = self.func(*self.args, **self.kwargs)
                    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/nix/store/75bf5mv3r07nn3skn9j2hyv6i8zksyhm-calibre-9.10.0/lib/calibre/calibre/gui2/device.py", line 661, in _upload_books
      return self.device.upload_books(files, names, on_card,
             ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
              metadata=metadata, end_session=False)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "calibre_plugins.dummy1.driver", line 422, in upload_books
      ws_client.upload_file(
      ~~~~~~~~~~~~~~~~~~~~~^
          host,
          ^^^^^
      ...<7 lines>...
          logger=self._log,
          ^^^^^^^^^^^^^^^^^
      )
      ^
    File "calibre_plugins.dummy1.ws_client", line 302, in upload_file
      client.send_binary(chunk)
      ~~~~~~~~~~~~~~~~~~^^^^^^^
    File "calibre_plugins.dummy1.ws_client", line 74, in send_binary
      self._send_frame(0x2, payload)
      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
    File "calibre_plugins.dummy1.ws_client", line 98, in _send_frame
      self.sock.sendall(header + masked)
      ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  TimeoutError: timed out
```

This change keeps the existing CrossPoint protocol intact and retries the current book from the beginning instead of aborting the full batch immediately. It also adds a short configurable delay between books to give the device and network a little time to settle before the next upload starts.

## Validation

- Uploaded a batch of files before and after this change, before I would get an upload failure after uploading between 5+ books, now it works even with 20+ books without issues.